### PR TITLE
[bugfix] event listeners not removed

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -19,7 +19,7 @@ export interface InfiniteScrollProps {
   onLoadMore: () => void;
 
   /**
-   * Scroll threshold 
+   * Scroll threshold
    */
   threshold?: number;
 
@@ -41,7 +41,7 @@ export class InfiniteScroll extends React.Component<InfiniteScrollProps, {}> {
 
   componentDidMount() {
     window.addEventListener('scroll', throttle(this.checkWindowScroll, this.props.throttle));
-    window.removeEventListener('resize', throttle(this.checkWindowScroll, this.props.throttle));
+    window.addEventListener('resize', throttle(this.checkWindowScroll, this.props.throttle));
   }
 
   componentWillUnmount() {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -40,13 +40,16 @@ export class InfiniteScroll extends React.Component<InfiniteScrollProps, {}> {
   private sentinel: HTMLDivElement;
 
   componentDidMount() {
-    window.addEventListener('scroll', throttle(this.checkWindowScroll, this.props.throttle));
-    window.addEventListener('resize', throttle(this.checkWindowScroll, this.props.throttle));
+    this.scrollHandler = throttle(this.checkWindowScroll, this.props.throttle);
+    this.resizeHandler = throttle(this.checkWindowScroll, this.props.throttle);
+
+    window.addEventListener('scroll', this.scrollHandler);
+    window.addEventListener('resize', this.resizeHandler);
   }
 
   componentWillUnmount() {
-    window.removeEventListener('scroll', throttle(this.checkWindowScroll, this.props.throttle));
-    window.removeEventListener('resize', throttle(this.checkWindowScroll, this.props.throttle));
+    window.removeEventListener('scroll', this.scrollHandler);
+    window.removeEventListener('resize', this.resizeHandler);
   }
 
   checkWindowScroll = () => {


### PR DESCRIPTION
JavaScript needs access to the original event listeners added to the queue to be able to find them and remove them from the event's queue.

This PR does the following:

1. replaces `removeEventListener` for `addEventListener` on mount for the resize event.
2. holds the event listeners in the component instance to be able to remove them later.