### PR TITLE
Invalid Example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ const ConnectedComponent = connect(/* ... */)(MyComponent);
 
 ```jsx
 import React from 'react'
-import InfiniteScroll from 'react-simple-infinite-scroll'
+import { InfiniteScroll } from 'react-simple-infinite-scroll'
 
 export class MyInfiniteScrollExample extends React.Component {
   state = {


### PR DESCRIPTION
The example hung me up because it appears `{ InfiniteScroll }` is supposed to be a named export