### PR TITLE
Using intersection observer instead of throttling resize/scroll events

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,9 +26,7 @@
     "build": "npm run clean && tsc --project tsconfig.json -m es6 --outDir es6 && webpack -p --config ./webpack.lib && webpack -p --config webpack.umd.js",
     "prepublish": "npm run build"
   },
-  "dependencies": {
-    "lodash.throttle": "^4.1.1"
-  },
+  "dependencies": {},
   "devDependencies": {
     "@types/jest": "^19.2.3",
     "@types/react": "^16.4.18",

--- a/src/__tests__/InfiniteScroll.tsx
+++ b/src/__tests__/InfiniteScroll.tsx
@@ -3,6 +3,10 @@ import * as renderer from 'react-test-renderer';
 
 import { InfiniteScroll } from '../.';
 
+window.IntersectionObserver = jest.fn(function() {
+  this.observe = jest.fn();
+});
+
 describe('<InfiniteScroll />', () => {
 
   it('renders InfiniteScroll correctly', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2494,11 +2494,6 @@ lodash.debounce@^4.0.8:
   resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
   integrity sha1-gteb/zCmfEAF/9XiUVMArZyk168=
 
-lodash.throttle@^4.1.1:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/lodash.throttle/-/lodash.throttle-4.1.1.tgz#c23e91b710242ac70c37f1e1cda9274cc39bf2f4"
-  integrity sha1-wj6RtxAkKscMN/HhzaknTMOb8vQ=
-
 lodash@^4.17.10, lodash@^4.17.4:
   version "4.17.11"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"


### PR DESCRIPTION
I used this package in a project, liked it and thought it could be made even simpler by removing `lodash.throttle` dependency and using IntersectionObserver api.

From my testing I don't think I broke it functionally. One downside is that IntersectionObserver is not implemented on IE, is this a deal-breaker for this PR?

Also, could you provide some more information about the "edge case" in componentDidUpdate?
Wouldn't it make sense to avoid loading more information if there is no scroll at all?

I would like to write a test for this situation to make sure how it's supposed to work.